### PR TITLE
Add Drupal 9.1

### DIFF
--- a/dates.js
+++ b/dates.js
@@ -33,12 +33,14 @@ const release_8_7 = date(2019, 5, 1);
 const release_8_8 = date(2019, 12, 4);
 const release_8_9 = date(2020, 6, 3);
 const release_9_0 = date(2020, 6, 3);
+const release_9_1 = date(2020, 12, 2);
 
 const eol_6 = date(2016, 2, 24);
 const eol_7 = date(2021, 11, 30);
 const eol_8_8 = date(2020, 12, 2);
 const eol_8 = date(2021, 11, 30); // [1]
 const eol_9_0 = date(2021, 6, 30);
+const eol_9_1 = date(2021, 12, 31); // TBA
 const eol_9 = date(2023, 12, 31); // [2]
 
 // [1] D8 EOL no later than Nov 2021. Could be 8.9 or 8.10

--- a/script.js
+++ b/script.js
@@ -96,6 +96,13 @@ function drawChart() {
       "resource": "prerelease",
       "start": release_9_0,
       "end": eol_9_0,
+    },
+    {
+      "taskID": "9.1",
+      "taskName": "Drupal 9.1",
+      "resource": "prerelease",
+      "start": release_9_1,
+      "end": eol_9_1,
     }
   ];
 


### PR DESCRIPTION
Release:

> December 2, 2020: Drupal 9.1.0 released. End of security support for 8.8.x.

https://www.drupal.org/core/release-cycle-overview#next-development-cycle

EOL TBA: Assume ~6 months after 9.0 EOL.

Generally, for D8+, x.y is in security support until x.y+2 is out:

> Security fixes are provided until the following minor release, approximately
six additional months (so each minor receives security coverage for one year in total and two minors receive security coverage at a time).

https://www.drupal.org/core/release-cycle-overview#overview
