### PR TITLE
Drupal 8.9 is still in bugfix

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,7 +86,7 @@ function drawChart() {
     {
       "taskID": "8.9",
       "taskName": "Drupal 8.9 LTS",
-      "resource": "security",
+      "resource": "bugfix",
       "start": release_8_9,
       "end": eol_8,
     },


### PR DESCRIPTION
The https://www.drupal.org/project/drupal/releases/8.9.12 bugfix release came out yesterday, as did https://www.drupal.org/project/drupal/releases/9.1.2, but none for 9.0.

* D8.9 is bugfix
* D9.0 is security only
* D9.1 is bugfix
